### PR TITLE
add support for OS integration and pybuild. 

### DIFF
--- a/backdoor.py
+++ b/backdoor.py
@@ -49,9 +49,9 @@ import signal
 import time
 from random import choice
 from optparse import OptionParser
-from pebin import pebin
-from elfbin import elfbin
-from machobin import machobin
+from bdfactory.pebin import pebin
+from bdfactory.elfbin import elfbin
+from bdfactory.machobin import machobin
 
 
 def signal_handler(signal, frame):

--- a/elfbin.py
+++ b/elfbin.py
@@ -37,11 +37,11 @@ import os
 import shutil
 import sys
 import tempfile
-from intel.LinuxIntelELF32 import linux_elfI32_shellcode
-from intel.LinuxIntelELF64 import linux_elfI64_shellcode
-from intel.FreeBSDIntelELF32 import freebsd_elfI32_shellcode
+from bdfactory.intel.LinuxIntelELF32 import linux_elfI32_shellcode
+from bdfactory.intel.LinuxIntelELF64 import linux_elfI64_shellcode
+from bdfactory.intel.FreeBSDIntelELF32 import freebsd_elfI32_shellcode
 #from intel.FreeBSDIntelELF64 import freebsd_elfI64_shellcode
-from arm.LinuxARMLELF32 import linux_elfarmle32_shellcode
+from bdfactory.arm.LinuxARMLELF32 import linux_elfarmle32_shellcode
 
 
 class elf():

--- a/machobin.py
+++ b/machobin.py
@@ -37,8 +37,8 @@ import struct
 import shutil
 import tempfile
 import sys
-from intel.MachoIntel64 import macho_intel64_shellcode
-from intel.MachoIntel32 import macho_intel32_shellcode
+from bdfactory.intel.MachoIntel64 import macho_intel64_shellcode
+from bdfactory.intel.MachoIntel32 import macho_intel32_shellcode
 
 
 class machobin():

--- a/payloadtests.py
+++ b/payloadtests.py
@@ -32,9 +32,9 @@ POSSIBILITY OF SUCH DAMAGE.
 
 '''
 
-import pebin
-import machobin
-import elfbin
+import bdfactory.pebin
+import bdfactory.machobin
+import bdfactory.elfbin
 import sys
 import os
 

--- a/pebin.py
+++ b/pebin.py
@@ -46,14 +46,14 @@ import string
 import re
 import tempfile
 from random import choice
-from winapi import winapi
-from intel.intelCore import intelCore
-from intel.intelmodules import eat_code_caves
-from intel.WinIntelPE32 import winI32_shellcode
-from intel.WinIntelPE64 import winI64_shellcode
-from onionduke import onionduke
-from onionduke.onionduke import write_rsrc
-from onionduke.onionduke import xor_file
+from bdfactory.winapi import winapi
+from bdfactory.intel.intelCore import intelCore
+from bdfactory.intel.intelmodules import eat_code_caves
+from bdfactory.intel.WinIntelPE32 import winI32_shellcode
+from bdfactory.intel.WinIntelPE64 import winI64_shellcode
+from bdfactory.onionduke import onionduke
+from bdfactory.onionduke.onionduke import write_rsrc
+from bdfactory.onionduke.onionduke import xor_file
 
 
 MachineTypes = {'0x0': 'AnyMachineType',

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python
+#
+# Authors:
+#   Philippe Thierry <phil@reseau-libre.net>
+
+import os
+import os.path
+
+from distutils.core import setup
+
+
+setup(
+    name="backdoor-factory",
+    #version=version.VERSION_STRING,
+    author="secretsquirrel",
+    description="Patch PE, ELF, Mach-O binaries with shellcode",
+    license="BSD-3-clause",
+    url="https://github.com/secretsquirrel/the-backdoor-factory",
+    packages=['bdfactory','bdfactory.intel','bdfactory.arm','bdfactory.winapi','bdfactory.onionduke','bdfactory.preprocessor'],
+    package_dir = {'bdfactory': ''},
+    py_modules=['bdfactory.pebin','bdfactory.elfbin','bdfactory.machobin'],
+    scripts=[
+        os.path.join("./", "backdoor.py"),
+    ],
+)


### PR DESCRIPTION
Hello!

Here is a patch i propose to help the integration of tbf in the os instead of using it directly from its source dir.
It contains a setup.py script to support pybuild-based install and add a bdfactory python package for clean integration in python dist-packages.
This patch has been made while porting the packaging from Kali to Debian.