### PR TITLE
Linux bintype added to the EI_OSABI option header

### DIFF
--- a/elfbin.py
+++ b/elfbin.py
@@ -344,6 +344,8 @@ class elfbin():
             if self.EI_CLASS == 0x2:
                 if self.EI_OSABI == 0x00:
                     self.bintype = linux_elfI64_shellcode
+                elif self.EI_OSABI == 0x03:
+                    self.bintype = linux_elfI64_shellcode
                 #elif self.EI_OSABI == 0x09:
                 #    self.bintype = freebsd_elfI64_shellcode
         elif self.e_machine == 0x28:  # ARM chipset


### PR DESCRIPTION
Trying to infect an ELF executable i was receiving the following message "Unusual binary type", i realize that there was a missing "Linux" option for the EI_OSABI header, i just added it and everything work just fine. I only add the option for the x64 architecture.