### PR TITLE
docs: fix simple typo, retreives -> retrieves

### DIFF
--- a/osslsigncode/osslsigncode.c
+++ b/osslsigncode/osslsigncode.c
@@ -2252,7 +2252,7 @@ static int verify_pe_file(char *indata, unsigned int peheader, int pe32plus,
 	return ret;
 }
 
-// extract_existing_pe_pkcs7 retreives a decoded PKCS7 struct corresponding to the
+// extract_existing_pe_pkcs7 retrieves a decoded PKCS7 struct corresponding to the
 // existing signature of the PE file.
 static PKCS7 *extract_existing_pe_pkcs7(char *indata, unsigned int peheader, int pe32plus,
 									   unsigned int sigpos, unsigned int siglen)


### PR DESCRIPTION
There is a small typo in osslsigncode/osslsigncode.c.

Should read `retrieves` rather than `retreives`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md